### PR TITLE
bugfix: wrong blocking use

### DIFF
--- a/main.go
+++ b/main.go
@@ -4,5 +4,4 @@ import "github.com/cdle/sillyGirl/core"
 
 func main() {
 	core.RunServer()
-	select {}
 }


### PR DESCRIPTION
`gin.Run` is already blocked, there is no need to `select{}` to block the process. If the api service is stopped, the program will not end normally due to `select{}`.